### PR TITLE
feat: use nuxt/icon

### DIFF
--- a/assets/icons/test666.svg
+++ b/assets/icons/test666.svg
@@ -1,0 +1,34 @@
+<!-- TODO:Test -->
+<svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <g clip-path="url(#clip0_1823_19390)">
+        <path
+            d="M3.99556 17.1494C5.23308 11.7934 10.003 8 15.5 8C20.997 8 25.7669 11.7934 27.0044 17.1494L27.7611 20.4241C28.7747 24.8109 25.4432 29 20.9408 29H10.0592C5.55684 29 2.22531 24.8109 3.23891 20.4241L3.99556 17.1494Z"
+            fill="url(#paint0_linear_1823_19390)" stroke="white" stroke-width="2" />
+        <path
+            d="M15.2424 7C12.0766 7 10.0547 4.57972 8.9077 1.92132C8.77921 1.62349 8.86271 1.4219 9.01416 1.28627C9.18862 1.13004 9.50755 1.02885 9.88512 1.17314L14.1492 2.80276C14.8589 3.07396 15.645 3.06583 16.3489 2.78002L20.277 1.185C20.6431 1.03634 20.9624 1.12505 21.1429 1.27491C21.3002 1.40557 21.3885 1.60135 21.2795 1.89519C20.2883 4.56659 18.4123 7 15.2424 7Z"
+            fill="url(#paint1_linear_1823_19390)" stroke="white" stroke-width="2" />
+        <rect x="10" y="18.6001" width="11.3143" height="1.88571" rx="0.942857" fill="#3971F3" />
+        <rect x="10" y="21.4287" width="11.3143" height="1.88571" rx="0.942857" fill="#3971F3" />
+        <rect x="16.6" y="17.6572" width="8.48571" height="1.88571" rx="0.942857" transform="rotate(90 16.6 17.6572)"
+            fill="#3971F3" />
+        <rect x="11.5566" y="12" width="8.48571" height="1.88571" rx="0.942857" transform="rotate(55.6351 11.5566 12)"
+            fill="#3971F3" />
+        <rect width="8.48571" height="1.88571" rx="0.942857"
+            transform="matrix(-0.564461 0.82546 0.82546 0.564461 19.5041 12)" fill="#3971F3" />
+        <rect x="11" y="6" width="8" height="2" rx="1" fill="#3971F3" />
+    </g>
+    <defs>
+        <linearGradient id="paint0_linear_1823_19390" x1="3.54286" y1="29.1481" x2="24.6431" y2="13.0297"
+            gradientUnits="userSpaceOnUse">
+            <stop stop-color="white" />
+            <stop offset="1" stop-color="#D2E9FF" />
+        </linearGradient>
+        <linearGradient id="paint1_linear_1823_19390" x1="15" y1="-1" x2="15" y2="8" gradientUnits="userSpaceOnUse">
+            <stop stop-color="white" />
+            <stop offset="1" stop-color="#D2E9FF" />
+        </linearGradient>
+        <clipPath id="clip0_1823_19390">
+            <rect width="30" height="30" fill="white" />
+        </clipPath>
+    </defs>
+</svg>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,7 +4,7 @@ import { defineNuxtConfig } from 'nuxt/config'
 export default defineNuxtConfig({
   compatibilityDate: '2024-04-03',
   devtools: {
-    enabled: false,
+    enabled: true,
   },
   ssr: false,
   modules: [
@@ -15,6 +15,7 @@ export default defineNuxtConfig({
     '@vueuse/nuxt',
     '@nuxt/eslint',
     '@nuxt/image',
+    '@nuxt/icon',
   ],
   css: ['~/assets/css/main.scss'],
   vite: {
@@ -33,5 +34,16 @@ export default defineNuxtConfig({
   },
   image: {
     dir: 'assets/image',
+  },
+  /**
+   * @see https://github.com/nuxt/icon
+   */
+  icon: {
+    customCollections: [
+      {
+        prefix: '',
+        dir: 'assets/icons',
+      },
+    ],
   },
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -41,7 +41,7 @@ export default defineNuxtConfig({
   icon: {
     customCollections: [
       {
-        prefix: '',
+        prefix: 'jdy', // 前缀
         dir: 'assets/icons',
       },
     ],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@antfu/eslint-config": "^3.7.3",
     "@nuxt/eslint": "^0.5.7",
+    "@nuxt/icon": "^1.5.6",
     "@nuxt/image": "^1.8.0",
     "@pinia/nuxt": "^0.5.4",
     "@unocss/eslint-plugin": "^0.63.0",

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -9,6 +9,7 @@
     <div class="p-4  w-full pt-[140px] box-border">
       <product-home-sort />
     </div>
-    <icon name="nuxt-v1" />
+    <!-- TODO: Test -->
+    <icon name="jdy:test666" size="100" mode="css" />
   </div>
 </template>

--- a/pages/index/index.vue
+++ b/pages/index/index.vue
@@ -9,5 +9,6 @@
     <div class="p-4  w-full pt-[140px] box-border">
       <product-home-sort />
     </div>
+    <icon name="nuxt-v1" />
   </div>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@nuxt/eslint':
         specifier: ^0.5.7
         version: 0.5.7(eslint@9.11.1(jiti@2.3.3))(magicast@0.3.5)(rollup@4.22.4)(typescript@5.6.2)(vite@5.4.8(@types/node@22.7.5)(sass@1.79.5)(terser@5.34.1))(webpack-sources@3.2.3)
+      '@nuxt/icon':
+        specifier: ^1.5.6
+        version: 1.5.6(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.8(@types/node@22.7.5)(sass@1.79.5)(terser@5.34.1))(vue@3.5.12(typescript@5.6.2))(webpack-sources@3.2.3)
       '@pinia/nuxt':
         specifier: ^0.5.4
         version: 0.5.5(magicast@0.3.5)(rollup@4.22.4)(typescript@5.6.2)(vue@3.5.12(typescript@5.6.2))(webpack-sources@3.2.3)
@@ -873,11 +876,19 @@ packages:
     resolution: {integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==}
     engines: {node: '>=18.18'}
 
+  '@iconify/collections@1.0.470':
+    resolution: {integrity: sha512-6N1f1iNMNWvM56pUhcv+0TSP6Apl2VRfejtZH8h9H8fMRiDsROWxeQeEBxI394QnVWrOyoK1XXnNyVbn6xlF6A==}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
   '@iconify/utils@2.1.33':
     resolution: {integrity: sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==}
+
+  '@iconify/vue@4.1.3-beta.1':
+    resolution: {integrity: sha512-N7iEOnWfhjbMqiyGMhotJKip23nrK5l3+T1hQwpEjKeMD2o4zOjm8zmeEfOOH81EXllhhOm7upR8jcH499YRWA==}
+    peerDependencies:
+      vue: '>=3'
 
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
@@ -964,6 +975,11 @@ packages:
     peerDependencies:
       vite: '*'
 
+  '@nuxt/devtools-kit@1.6.0':
+    resolution: {integrity: sha512-kJ8mVKwTSN3tdEVNy7mxKCiQk9wsG5t3oOrRMWk6IEbTSov+5sOULqQSM/+OWxWsEDmDfA7QlS5sM3Ti9uMRqQ==}
+    peerDependencies:
+      vite: '*'
+
   '@nuxt/devtools-wizard@1.5.1':
     resolution: {integrity: sha512-09VqUYnL8dh31GK85g9+L1xZCXCmieOBWsV9H5a3ZA7wNepDjbrmaRFr/KSA6fsI7AZoqzkNuRsGUzEksEDxpg==}
     hasBin: true
@@ -995,6 +1011,9 @@ packages:
         optional: true
       vite-plugin-eslint2:
         optional: true
+
+  '@nuxt/icon@1.5.6':
+    resolution: {integrity: sha512-7l99CWc/laHphSsoLikh99Hkwjv+59cwAMJ0f9eZddBV+vO7zLGWwocH/TDNjlX0IACgVoG+AfbP/p1fqlLKpg==}
 
   '@nuxt/image@1.8.1':
     resolution: {integrity: sha512-qNj7OCNsoGcutGOo1R2PYp4tQ/6uD77aSakyDoVAmLSRJBmhFTnT2+gIqVD95JMmkSHgYhmSX4gGxnaQK/t1cw==}
@@ -5821,6 +5840,10 @@ snapshots:
 
   '@humanwhocodes/retry@0.3.1': {}
 
+  '@iconify/collections@1.0.470':
+    dependencies:
+      '@iconify/types': 2.0.0
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@2.1.33':
@@ -5834,6 +5857,11 @@ snapshots:
       mlly: 1.7.2
     transitivePeerDependencies:
       - supports-color
+
+  '@iconify/vue@4.1.3-beta.1(vue@3.5.12(typescript@5.6.2))':
+    dependencies:
+      '@iconify/types': 2.0.0
+      vue: 3.5.12(typescript@5.6.2)
 
   '@ioredis/commands@1.2.0': {}
 
@@ -5931,6 +5959,18 @@ snapshots:
   '@nuxt/devalue@2.0.2': {}
 
   '@nuxt/devtools-kit@1.5.1(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.8(@types/node@22.7.5)(sass@1.79.5)(terser@5.34.1))(webpack-sources@3.2.3)':
+    dependencies:
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.13.2(rollup@4.22.4)(webpack-sources@3.2.3)
+      execa: 7.2.0
+      vite: 5.4.8(@types/node@22.7.5)(sass@1.79.5)(terser@5.34.1)
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+      - webpack-sources
+
+  '@nuxt/devtools-kit@1.6.0(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.8(@types/node@22.7.5)(sass@1.79.5)(terser@5.34.1))(webpack-sources@3.2.3)':
     dependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
       '@nuxt/schema': 3.13.2(rollup@4.22.4)(webpack-sources@3.2.3)
@@ -6059,6 +6099,29 @@ snapshots:
       - typescript
       - utf-8-validate
       - vite
+      - webpack-sources
+
+  '@nuxt/icon@1.5.6(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.8(@types/node@22.7.5)(sass@1.79.5)(terser@5.34.1))(vue@3.5.12(typescript@5.6.2))(webpack-sources@3.2.3)':
+    dependencies:
+      '@iconify/collections': 1.0.470
+      '@iconify/types': 2.0.0
+      '@iconify/utils': 2.1.33
+      '@iconify/vue': 4.1.3-beta.1(vue@3.5.12(typescript@5.6.2))
+      '@nuxt/devtools-kit': 1.6.0(magicast@0.3.5)(rollup@4.22.4)(vite@5.4.8(@types/node@22.7.5)(sass@1.79.5)(terser@5.34.1))(webpack-sources@3.2.3)
+      '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)
+      consola: 3.2.3
+      local-pkg: 0.5.0
+      mlly: 1.7.2
+      ohash: 1.1.4
+      pathe: 1.1.2
+      std-env: 3.7.0
+      tinyglobby: 0.2.9
+    transitivePeerDependencies:
+      - magicast
+      - rollup
+      - supports-color
+      - vite
+      - vue
       - webpack-sources
 
   '@nuxt/image@1.8.1(ioredis@5.4.1)(magicast@0.3.5)(rollup@4.22.4)(webpack-sources@3.2.3)':


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了新的图标组件，显示名称为“jdy:test666”，大小为100，模式为“css”。
  - 引入了`@nuxt/icon`模块，增强了Nuxt应用程序的功能。
  - 新增自定义图标配置，支持自定义图标目录。

- **依赖更新**
  - 在`devDependencies`中添加了`@nuxt/icon`依赖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->